### PR TITLE
use XmlCompiler.compile instead of readXmlFile

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -17,7 +17,7 @@ class Main
 	
 	public function new()
 	{
-		XmlCompiler.readXmlFile( "configuration/context.xml" );
+		XmlCompiler.compile( "configuration/context.xml" );
 	}
 	
 }


### PR DESCRIPTION
In reference to https://github.com/DoclerLabs/hexIoC/commit/6cda7e468ee239ce10dc2fdb266ec2d21068febc 

Just discovered your interesting framework while I was searching for a Haxe-based environment as an alternative to my usual WevDev setup.

hexMachina seems to be a sane alternative to TypeScript+*put-a-JS-framework-in-here*. 😸 

Kind regards,